### PR TITLE
Refactor login authentication with form request

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\LoginRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -12,12 +13,9 @@ class LoginController extends Controller
     {
         return view('auth.login');
     }
-    public function authenticate(Request $request)
+    public function authenticate(LoginRequest $request)
     {
-        $credentials = $request->validate([
-            'email' => ['required', 'email'],
-            'password' => ['required', 'string', 'min:6'],
-        ]);
+        $credentials = $request->validated();
 
         if (Auth::attempt($credentials, $request->filled('remember'))) {
             $request->session()->regenerate();

--- a/src/app/Http/Requests/LoginRequest.php
+++ b/src/app/Http/Requests/LoginRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string', 'min:6'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- create `LoginRequest` with email and password rules
- use `LoginRequest` in `LoginController::authenticate` instead of inline validation

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689b80883b6c8320adaa3be8757c4f57