### PR TITLE
Add feature tests for authentication and password reset

### DIFF
--- a/src/tests/Feature/AuthTest.php
+++ b/src/tests/Feature/AuthTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Tests\TestCase;
+
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_login_with_valid_credentials(): void
+    {
+        $password = 'secret123';
+        $user = User::factory()->create([
+            'password' => Hash::make($password),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticatedAs($user);
+    }
+
+    public function test_user_cannot_login_with_invalid_credentials(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('correct-password'),
+        ]);
+
+        $response = $this->from('/login')->post('/login', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHasErrors('error-login');
+        $this->assertGuest();
+    }
+
+    public function test_password_reset_link_email_is_sent(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+        $this->assertAuthenticated();
+
+        $response = $this->post('/forgot-password', [
+            'email' => $user->email,
+        ]);
+
+        $response->assertSessionHas('status');
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_user_can_reset_password_with_valid_token(): void
+    {
+        $user = User::factory()->create();
+
+        $token = Password::broker()->createToken($user);
+
+        $response = $this->post('/reset-password', [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ]);
+
+        $response->assertRedirect('/login');
+
+        $loginResponse = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'new-password',
+        ]);
+
+        $loginResponse->assertRedirect('/');
+        $this->assertAuthenticatedAs($user);
+    }
+}


### PR DESCRIPTION
## Summary
- test successful and failed login flows
- verify password reset email dispatch
- ensure users can reset password and log in with new credentials

## Testing
- `cd src && ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b8089e1a48320a4160b21823d5e9f