### PR TITLE
Add admin panel with user role management

### DIFF
--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AdminController extends Controller
+{
+    public function index()
+    {
+        $users = User::all();
+        return view('admin.index', compact('users'));
+    }
+
+    public function create()
+    {
+        return view('admin.create', ['roles' => User::ROLES]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:6'],
+            'role' => ['required', 'in:admin,manager,developer,tester'],
+        ]);
+
+        User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+            'role' => $data['role'],
+        ]);
+
+        return redirect()->route('admin.dashboard');
+    }
+}

--- a/src/app/Http/Middleware/AdminMiddleware.php
+++ b/src/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!auth()->check() || auth()->user()->role !== 'admin') {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -12,6 +12,8 @@ class User extends Authenticatable
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
 
+    public const ROLES = ['admin', 'manager', 'developer', 'tester'];
+
     /**
      * The attributes that are mass assignable.
      *
@@ -21,6 +23,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('03070307'),
             'remember_token' => Str::random(10),
+            'role' => 'developer',
         ];
     }
 

--- a/src/database/migrations/0001_01_01_000003_add_role_to_users_table.php
+++ b/src/database/migrations/0001_01_01_000003_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('role', ['admin', 'manager', 'developer', 'tester'])->default('developer');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/src/resources/views/admin/create.blade.php
+++ b/src/resources/views/admin/create.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create User</h1>
+<form method="POST" action="{{ route('admin.users.store') }}" class="mt-3">
+    @csrf
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Role</label>
+        <select name="role" class="form-select">
+            @foreach($roles as $role)
+                <option value="{{ $role }}">{{ ucfirst($role) }}</option>
+            @endforeach
+        </select>
+    </div>
+    <button type="submit" class="btn btn-success">Save</button>
+</form>
+@endsection

--- a/src/resources/views/admin/index.blade.php
+++ b/src/resources/views/admin/index.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h1>Admin Panel</h1>
+    <a href="{{ route('admin.users.create') }}" class="btn btn-primary">Create User</a>
+</div>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($users as $user)
+            <tr>
+                <td>{{ $user->name }}</td>
+                <td>{{ $user->email }}</td>
+                <td>{{ $user->role }}</td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/src/resources/views/components/header.blade.php
+++ b/src/resources/views/components/header.blade.php
@@ -39,6 +39,11 @@
         <ul class="list-unstyled list-group list-group-flush  custom-bg">
             <li class="list-group-item"><a href="{{route('home')}}" class="d-block py-2">Головна</a></li>
             <li class="list-group-item"><a href="#" class="d-block py-2">Задачі</a></li>
+            @auth
+                @if(auth()->user()->role === 'admin')
+                    <li class="list-group-item"><a href="{{ route('admin.dashboard') }}" class="d-block py-2">Адмін панель</a></li>
+                @endif
+            @endauth
             @if (Route::has('login'))
                 @auth
                     <li class="list-group-item">

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
+use App\Http\Controllers\AdminController;
 
 Route::get('/', function () {
     return view('pages.home');
@@ -18,3 +19,9 @@ Route::get('/forgot-password', [PasswordResetLinkController::class, 'create'])->
 Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])->name('password.email');
 Route::get('/reset-password/{token}', [NewPasswordController::class, 'create'])->name('password.reset');
 Route::post('/reset-password', [NewPasswordController::class, 'store'])->name('password.update');
+
+Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/', [AdminController::class, 'index'])->name('dashboard');
+    Route::get('/users/create', [AdminController::class, 'create'])->name('users.create');
+    Route::post('/users', [AdminController::class, 'store'])->name('users.store');
+});

--- a/src/tests/Feature/AdminPanelTest.php
+++ b/src/tests/Feature/AdminPanelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminPanelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_access_dashboard(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $response = $this->actingAs($admin)->get('/admin');
+        $response->assertStatus(200);
+    }
+
+    public function test_non_admin_is_forbidden(): void
+    {
+        $user = User::factory()->create(['role' => 'developer']);
+        $response = $this->actingAs($user)->get('/admin');
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_create_user(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($admin)->post('/admin/users', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'role' => 'manager',
+        ]);
+
+        $response->assertRedirect('/admin');
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+            'role' => 'manager',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add user roles and admin-restricted middleware
- create admin panel to list and create users
- show admin panel link for admins in navigation

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689b85e968bc8320aa153d802d0d2d15